### PR TITLE
Add custom datetime parser based on the fronend consept.

### DIFF
--- a/server/cshr/serializers/event.py
+++ b/server/cshr/serializers/event.py
@@ -5,14 +5,14 @@ from server.cshr.serializers.users import BaseUserSerializer
 
 
 class EventSerializer(ModelSerializer):
-    peoples = SerializerMethodField()
+    custom_people = SerializerMethodField()
     date = SerializerMethodField()
 
     class Meta:
         model = Event
-        fields = ["people", "name", "description", "location", "date", "peoples"]
+        fields = ["people", "name", "description", "location", "date", "custom_people"]
 
-    def get_peoples(self, obj: Event) -> BaseUserSerializer:
+    def get_custom_people(self, obj: Event) -> BaseUserSerializer:
         return BaseUserSerializer(obj.people.all(), many=True).data
 
     def get_date(self, obj: Event) -> Dict:

--- a/server/cshr/serializers/event.py
+++ b/server/cshr/serializers/event.py
@@ -1,8 +1,25 @@
-from rest_framework.serializers import ModelSerializer
+from typing import Dict
+from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from server.cshr.models.event import Event
+from server.cshr.serializers.users import BaseUserSerializer
 
 
 class EventSerializer(ModelSerializer):
+    peoples = SerializerMethodField()
+    date = SerializerMethodField()
+
     class Meta:
         model = Event
-        fields = "__all__"
+        fields = ["people", "name", "description", "location", "date", "peoples"]
+
+    def get_peoples(self, obj: Event) -> BaseUserSerializer:
+        return BaseUserSerializer(obj.people.all(), many=True).data
+
+    def get_date(self, obj: Event) -> Dict:
+        return {
+            "year": obj.date.year,
+            "month": obj.date.month,
+            "day": obj.date.day,
+            "hour": obj.date.hour,
+            "minute": obj.date.minute,
+        }

--- a/server/cshr/serializers/meetings.py
+++ b/server/cshr/serializers/meetings.py
@@ -1,5 +1,5 @@
 from server.cshr.models.meetings import Meetings
-from typing import List
+from typing import Dict, List
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from server.cshr.models.users import User
 from server.cshr.serializers.users import BaseUserSerializer
@@ -9,11 +9,21 @@ class MeetingsSerializer(ModelSerializer):
     """Class to serialize Meeting objects"""
 
     invited_users: List[User] = SerializerMethodField()
+    date = SerializerMethodField()
 
     class Meta:
         model = Meetings
-        fields = ("invited_users", "date", "meeting_link")
+        fields = ("id", "invited_users", "date", "meeting_link")
 
     def get_invited_users(self, obj: Meetings) -> List[BaseUserSerializer]:
         """Returns a list of users that invited to the meeting."""
         return BaseUserSerializer(obj.invited_users.all(), many=True).data
+
+    def get_date(self, obj: Meetings) -> Dict:
+        return {
+            "year": obj.date.year,
+            "month": obj.date.month,
+            "day": obj.date.day,
+            "hour": obj.date.hour,
+            "minute": obj.date.minute,
+        }

--- a/server/cshr/serializers/users.py
+++ b/server/cshr/serializers/users.py
@@ -197,4 +197,4 @@ class BaseUserSerializer(ModelSerializer):
 
     class Meta:
         model = User
-        fields = ["full_name", "email", "image"]
+        fields = ["id", "full_name", "email", "image"]

--- a/server/cshr/serializers/vacations.py
+++ b/server/cshr/serializers/vacations.py
@@ -29,6 +29,7 @@ class LandingPageVacationsSerializer(ModelSerializer):
     class Meta:
         model = Vacation
         fields = [
+            "id",
             "reason",
             "from_date",
             "end_date",

--- a/server/cshr/tests/test_event.py
+++ b/server/cshr/tests/test_event.py
@@ -84,6 +84,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [1, 2],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -97,6 +98,7 @@ class EventTests(APITestCase):
             "name": "test event",
             "description": "our first test event",
             "people": [1, 2],
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -111,6 +113,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -127,6 +130,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [1, 2],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -146,6 +150,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [1, 2],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -165,6 +170,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [1, 2],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -177,19 +183,6 @@ class EventTests(APITestCase):
 
     def test_delete_invalid_event(self) -> Event:
         """test to delete invalid event"""
-        """add evvent"""
-        url = "/api/event/"
-        data = {
-            "name": "test event",
-            "description": "our first test event",
-            "people": [1, 2],
-            "location": "Cairo Egypt",
-        }
-        self.headers = client.credentials(
-            HTTP_AUTHORIZATION="Bearer " + self.access_token_user
-        )
-        response = client.post(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         url = "/api/event/10/"
         response = client.delete(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -211,6 +204,7 @@ class EventTests(APITestCase):
             "description": "our first test event",
             "people": [1, 2],
             "location": "Cairo Egypt",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -228,8 +222,9 @@ class EventTests(APITestCase):
         data = {
             "name": "test event",
             "description": "our first test event",
-            "people": [1, 2],
             "location": "Cairo Egypt",
+            "people": [1],
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -237,8 +232,23 @@ class EventTests(APITestCase):
         response = client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         url = "/api/event/1/"
-        data = {
-            "people": [-1, 1],
-        }
+        data["people"] = [-50]
         response = client.put(url, data, format="json")
         self.assertEqual(response.status_code, 400)
+
+    def test_create_event_invalid_date_format(self) -> Event:
+        """create event with no date"""
+        url = "/api/event/"
+        data = {
+            "name": "Shelby Austin",
+            "description": "Eius odio recusandae Ipsa consectetur vitae culpa aliquid veniam reiciendis numquam \
+                sed quae aut iusto rerum vel nihil neque et",
+            "location": "Deserunt amet aut saepe autem id eveniet non aliquip voluptas minima cupiditate nostrud hic ea",
+            "date": "2022-08-23ds",
+            "people": [1],
+        }
+        self.headers = client.credentials(
+            HTTP_AUTHORIZATION="Bearer " + self.access_token_user
+        )
+        response = client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/server/cshr/tests/test_meetings.py
+++ b/server/cshr/tests/test_meetings.py
@@ -81,7 +81,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -92,7 +92,10 @@ class MeetingsTests(APITestCase):
 
     def test_create_meeting_no_meeting_link(self) -> Meetings:
         url = "/api/meeting/"
-        data = {"date": "2022-08-29T12:26:26.380Z", "invited_users": [1, 2]}
+        data = {
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
+            "invited_users": [1, 2],
+        }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
         )
@@ -103,7 +106,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
         }
         self.headers = client.credentials(
             HTTP_AUTHORIZATION="Bearer " + self.access_token_user
@@ -118,7 +121,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -136,7 +139,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -154,7 +157,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -172,7 +175,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -198,7 +201,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -209,7 +212,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/1/"
         data = {
             "meeting_link": "updated meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         response = client.put(url, data, format="json")
@@ -220,7 +223,7 @@ class MeetingsTests(APITestCase):
         url = "/api/meeting/"
         data = {
             "meeting_link": "meeting link",
-            "date": "2022-08-29T12:26:26.380Z",
+            "date": {"year": 2022, "month": 9, "day": 8, "hour": 16, "minute": 24},
             "invited_users": [1, 2],
         }
         self.headers = client.credentials(
@@ -232,3 +235,17 @@ class MeetingsTests(APITestCase):
         data = {"invited_users": [-1]}
         response = client.put(url, data, format="json")
         self.assertEqual(response.status_code, 400)
+
+    def test_create_meeting_invalid_date_format(self) -> Meetings:
+        """create meeting with no date"""
+        url = "/api/meeting/"
+        data = {
+            "meeting_link": "meeting link",
+            "date": "2022-08-23:25p0",
+            "invited_users": [1, 2],
+        }
+        self.headers = client.credentials(
+            HTTP_AUTHORIZATION="Bearer " + self.access_token_user
+        )
+        response = client.post(url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/server/cshr/utils/parse_date.py
+++ b/server/cshr/utils/parse_date.py
@@ -1,0 +1,73 @@
+"""This file containes parse date function that takes an obj and returns a datetime inctance."""
+from typing import Dict, List
+from datetime import datetime
+
+from server.cshr.api.response import CustomResponse
+
+
+class CSHRDate:
+    def __init__(self, date: Dict) -> None:
+        self.date = date
+        self.required_fields: List = ["year", "month", "day", "hour", "minute"]
+
+    def no_provided_date(self):
+        return CustomResponse.bad_request(
+            error=[{"required_fields": {"date": {"required": True, "type": "dict"}}}],
+            message="You must provide date field and must follow this pattern {}".format(
+                self.required_fields
+            ),
+        )
+
+    def wrong_provided_date(self):
+        return CustomResponse.bad_request(
+            error=[{"required_fields": {"date": {"required": True, "type": "dict"}}}],
+            message="You must provide date field as dict type and must follow this pattern {}".format(
+                self.required_fields
+            ),
+        )
+
+    def error(self):
+        provided_fields: List = []
+        for field in self.required_fields:
+            if field not in self.date.keys():
+                provided_fields.append(field)
+        return CustomResponse.bad_request(
+            error=[
+                {
+                    "required_fields": {
+                        "date": {
+                            "required": True,
+                            "type": "dict",
+                            "must_provided_fields": provided_fields,
+                        }
+                    }
+                }
+            ],
+            message="Please make sure that your date field containes {}".format(
+                self.required_fields
+            ),
+        )
+
+    def parse(self) -> datetime:
+        """This function takes a dict and returns a datetime inctance."""
+        if self.date is None:
+            return self.no_provided_date()
+        elif type(self.date) != dict:
+            return self.wrong_provided_date()
+        else:
+            if (
+                self.date.get("year")
+                and self.date.get("month")
+                and self.date.get("day")
+                and self.date.get("hour")
+                and self.date.get("minute")
+            ):
+                parsing: datetime = datetime(
+                    year=self.date.get("year"),
+                    month=self.date.get("month"),
+                    day=self.date.get("day"),
+                    hour=self.date.get("hour"),
+                    minute=self.date.get("minute"),
+                )
+                return parsing
+            return self.error()

--- a/server/cshr/views/meetings.py
+++ b/server/cshr/views/meetings.py
@@ -1,3 +1,4 @@
+import datetime
 from server.cshr.serializers.meetings import MeetingsSerializer
 from server.cshr.models.users import User
 from server.cshr.api.permission import UserIsAuthenticated
@@ -8,6 +9,8 @@ from rest_framework.request import Request
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from server.cshr.api.response import CustomResponse
+
+from server.cshr.utils.parse_date import CSHRDate
 
 
 class MeetingsApiView(ViewSet, GenericAPIView):
@@ -20,13 +23,17 @@ class MeetingsApiView(ViewSet, GenericAPIView):
         """Method to create a new meeting"""
         serializer = self.get_serializer(data=request.data)
         if serializer.is_valid():
-            currentUser: User = get_user_by_id(request.user.id)
-            serializer.save(host_user=currentUser)
-            return CustomResponse.success(
-                data=serializer.data,
-                message="meeting is created successfully",
-                status_code=201,
-            )
+            current_user: User = get_user_by_id(request.user.id)
+            provided_date: CSHRDate = CSHRDate(request.data.get("date"))
+            parsing: datetime.datetime = provided_date.parse()
+            if type(parsing) == datetime.datetime:
+                serializer.save(host_user=current_user, date=parsing)
+                return CustomResponse.success(
+                    data=serializer.data,
+                    message="meeting is created successfully",
+                    status_code=201,
+                )
+            return parsing
         return CustomResponse.bad_request(
             error=serializer.errors, message="meeting creation failed"
         )

--- a/server/settings.py
+++ b/server/settings.py
@@ -10,9 +10,7 @@ DEBUG = config("DJANGO_DEBUG") == "ON"
 
 CELERY_IMPORTS = ("server.cshr.celery.send_email",)
 
-ALLOWED_HOSTS = [
-    "127.0.0.1",
-]
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 
 # Application definition
 INSTALLED_APPS = [
@@ -143,7 +141,7 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
A new feature was added:
new DateTime parser to parse custom DateTime.


usage.
```python 
#inside any post function that contains a DateTime field just do it.
#dont forget to import CSHRDate
#from server.cshr.utils.parse_date import CSHRDate
          provided_date: CSHRDate = CSHRDate(request.data.get("date"))
            parsing: datetime.datetime = provided_date.parse()
            if type(parsing) == datetime.datetime:
                serializer.save(date=parsing)
                return CustomResponse.success(
                    data=serializer.data,
                    message="event is created successfully",
                    status_code=201,
                )
            return parsing
```

